### PR TITLE
Feature: Add function to retrieve Spotify access token from refresh t…

### DIFF
--- a/spotify/accessToken.js
+++ b/spotify/accessToken.js
@@ -1,0 +1,51 @@
+import querystring from "node:querystring";
+import 'dotenv/config'
+
+/**
+ * Retrieves a Spotify access token using the provided refresh token.
+ *
+ * This function sends a POST request to the Spotify Accounts service to obtain
+ * an access token using the provided refresh token and client credentials.
+ *
+ * @async
+ * @function  getAccessToken
+ * @throws    {Error} If there's an issue with the network request or the response.
+ * @returns   {Promise<object>} A Promise that resolves to an object containing the access token.
+ */
+const getAccessToken = async () => {
+  try {
+    // Get the required credentials and refresh token from environment variables
+    const clientId = process.env.SPOTIFY_CLIENT_ID;
+    const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+    const refreshToken = process.env.SPOTIFY_REFRESH_TOKEN;
+
+    // Spotify Accounts API endpoint URL
+    const url = `https://accounts.spotify.com/api/token`;
+
+    // Create a Base64-encoded "Basic" authorization header
+    const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+    // Make an HTTP POST request to obtain a new access token
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${basic}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: querystring.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+    });
+
+    // Ensure the response is in JSON format and return the parsed JSON data
+    const responseData = await response.json();
+
+    return responseData;
+  } 
+  catch (error) {
+    throw new Error(`Failed to retrieve Spotify access token: ${error.message}`);
+  }
+};
+
+export default getAccessToken;


### PR DESCRIPTION
**Pull Request Description:**

This pull request introduces a new feature that enhances our application by adding a function for retrieving a Spotify access token from a refresh token. Here's a breakdown of the changes included in this pull request:

**Changes Made:**

Added a new JavaScript function getAccessToken to the codebase.
The getAccessToken function fetches an access token from the Spotify Accounts service using the provided client credentials and a refresh token.
The function handles errors gracefully and returns the obtained access token as an object.
Why this change is necessary:

The addition of this function enables our application to seamlessly refresh Spotify access tokens, ensuring uninterrupted access to Spotify services for our users.
It enhances the overall user experience by automating the process of token renewal.

**How to test:**

Ensure you have the required environment variables (SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, SPOTIFY_REFRESH_TOKEN) set appropriately.
Call the getAccessToken function in your code and verify that it returns a valid access token.
Test the function with various scenarios, including invalid credentials or refresh tokens, to ensure it handles errors correctly.

**Related Issue:**
Closes #<issue_number> (if applicable)

Please review this pull request, and feel free to provide feedback or suggestions for improvement. Your feedback is highly appreciated!

**Screenshots or Additional Information (if applicable):**
N/A